### PR TITLE
Fix camera log persistence

### DIFF
--- a/app/src/main/java/com/example/cameramonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/cameramonitor/MainActivity.kt
@@ -31,9 +31,7 @@ class MainActivity : AppCompatActivity() {
 
     // Лямбда, принимающая (camera, status, pkg)
     private val cameraReceiver = CameraBroadcastReceiver { camera, status, pkg ->
-        tvLog.append("Ваш start\n")
         appendLog(camera, status, pkg)
-        tvLog.append("Ваш end\n")
         sendCameraNotification(camera, status, pkg)
     }
 
@@ -71,6 +69,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         registerReceiver(cameraReceiver, CameraBroadcastReceiver.intentFilter())
+        tvLog.text = CameraMonitorService.eventLog.joinToString("\n")
     }
 
     override fun onPause() {


### PR DESCRIPTION
## Summary
- keep a persistent list of camera events in `CameraMonitorService`
- restore the log when `MainActivity` resumes
- remove debug log lines

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f4cca37f083268e57bc42e6eb1d5c